### PR TITLE
Minor bugfixes

### DIFF
--- a/R/plotSubannual.R
+++ b/R/plotSubannual.R
@@ -376,7 +376,7 @@ plotSubannual <- function(fields, # can be a Field or a list of Fields
   if(length(facet.vars) > 0) p <- p + facet_wrap(facet.vars, ...)
   
   # overall text multiplier
-  if(!missing(text.multiplier)) p <- p + theme(text = element_text(size = theme_get()$text$size * text.multiplier))
+  if(!is.null(text.multiplier)) p <- p + theme(text = element_text(size = theme_get()$text$size * text.multiplier))
   
   return(p)
   

--- a/R/plotTemporal.R
+++ b/R/plotTemporal.R
@@ -354,7 +354,9 @@ plotTemporal <- function(fields,
   if(!is.null(x.lim)) p <- p + xlim(x.lim)
   if(!is.null(y.lim)) p <- p + scale_y_continuous(limits = y.lim, name = y.label)
   else p <- p + labs(y = y.label)
-  
+
+  if (!is.null(x.label)) p <- p + labs(x = x.label)
+
   # facetting
   if(length(vars.facet > 0)){
     suppressWarnings( p <- p + facet_wrap(vars.facet, ...))


### PR DESCRIPTION
- Fixed the case where we explicitly pass `text.multiplier = NULL` into `plotSubannual()`. A NULL text size should not be passed to ggplot
- Fixed `plotTemporal()` ignoring the `x.label` argument. It's now used in an equivalent way to the `y.label` argument. (The other solution would be to remove the `x.label` argument from the function if we don't want it there. Either way, having it but ignoring it seems misleading)