### PR TITLE
Improve automatic axis limits in plotSpatialComparison()

### DIFF
--- a/R/plotSpatialComparison.R
+++ b/R/plotSpatialComparison.R
@@ -167,7 +167,7 @@ plotSpatialComparison <- function(comparisons,
       
       # get max value for making the scale symmetric
       if(symmetric.scale && missing(limits)) {
-        for(this.layer in layers.to.plot)  max.for.scale <- max(max.for.scale, max(abs(object@data[[this.layer]])))
+        for(this.layer in layers.to.plot)  max.for.scale <- max(max.for.scale, max(abs(object@data[[this.layer]]), na.rm = TRUE))
       }
       
     }


### PR DESCRIPTION
Previously, if the data being plotted contained NA values, and limits were not explicitly passed into this function, the automatically-calculated axis limits would be NA, which would cause the plots to render as monotone grey, and no scale would be drawn.

The solution is to call max(..., na.rm = TRUE), which tells the max() function to ignore NA values. In practice, users should carefully consider how to handle NA values on their end, but it doesn't hurt here to do the best we can with the data we've been given.

As always, I'm happy to discuss if you'd rather take a different approach here.